### PR TITLE
Improve jenkins build

### DIFF
--- a/domain_eventbus.tf
+++ b/domain_eventbus.tf
@@ -50,4 +50,7 @@ resource "aws_cloudwatch_event_target" "this" {
   role_arn       = aws_iam_role.domain_bus_invoke_local_event_buses.arn
   rule           = "${each.value.name}-${each.value.domain}"
   arn            = each.value.target_bus_arn
+
+  depends_on = [aws_cloudwatch_event_rule.this]
+
 }


### PR DESCRIPTION
add "depends on" at the target, because jenkins will always fail during creating the target, because the specific rule does not yet exist